### PR TITLE
Add ppx version constraint

### DIFF
--- a/fstar/default.nix
+++ b/fstar/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, makeWrapper, which, ocamlPackages, sd, sphinx, python39Packages
-, z3, src }@inputs:
+, z3, src, fetchFromGitHub }@inputs:
 let
   inherit (import ./fstar-factory.nix {
-    inherit stdenv lib makeWrapper which ocamlPackages sd;
+    inherit stdenv lib makeWrapper which ocamlPackages sd fetchFromGitHub;
     z3 = z3;
   })
     binary-of-fstar check-fstar;


### PR DESCRIPTION
Hello again!

Here is a PoC, reusing the following nixpkgs PR: https://github.com/NixOS/nixpkgs/pull/195515 . I'm curious about any better way to do that.
Assuming I use a dedicated nixpkgs input (eg `work-nixpkgs`) in my system flake (as `hacl-nix.inputs.nixpkgs.follows = "work-nixpkgs"`), another way of fixing this would be to specify an overlay for this input that would be taken into account at build time? I did not manage to find such a way, thus the only "local" fix I have is to pin the nixpkgs input to an older revision.

Thank you very much again!